### PR TITLE
 RPC port change to 13322

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -32,7 +32,7 @@ class CBaseMainParams : public CBaseChainParams
 public:
     CBaseMainParams()
     {
-        nRPCPort = 3322;
+        nRPCPort = 13322;
     }
 };
 static CBaseMainParams mainParams;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -586,7 +586,7 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:3322/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:13322/\n";
 }
 
 void RPCRegisterTimerInterface(RPCTimerInterface *iface)


### PR DESCRIPTION
Moved rpc port from 3322 to 13322 since its in use in Sovereigncoin